### PR TITLE
Refatora modelos

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,14 +3,10 @@ class Category < ApplicationRecord
 
   has_many :transactions, dependent: :destroy
 
-  enumerize :category_type, in: [:income, :expense], default: :expense
+  enumerize :category_type, in: %i[income expense], default: :expense, scope: :shallow
 
   validates :description, presence: true, length: { minimum: 2, maximum: 100 }
   validates :category_type, presence: true
-
-  scope :incomes, -> { where(category_type: :income) }
-  scope :expenses, -> { where(category_type: :expense) }
-  scope :by_type, ->(type) { where(category_type: type) }
 
   def income?
     category_type == 'income'

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,18 +3,10 @@ class Category < ApplicationRecord
 
   has_many :transactions, dependent: :destroy
 
-  enumerize :category_type, in: %i[income expense], default: :expense, scope: :shallow
+  enumerize :category_type, in: %i[income expense], default: :expense, scope: :shallow, predicates: true
 
   validates :description, presence: true, length: { minimum: 2, maximum: 100 }
   validates :category_type, presence: true
-
-  def income?
-    category_type == 'income'
-  end
-
-  def expense?
-    category_type == 'expense'
-  end
 
   def to_s
     description

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -6,11 +6,11 @@ class Family < ApplicationRecord
   validates :description, length: { maximum: 500 }
 
   def total_income
-    transactions.joins(:category).where(categories: { category_type: 'income' }).sum(:amount)
+    transactions.income.sum(:amount)
   end
 
   def total_expenses
-    transactions.joins(:category).where(categories: { category_type: 'expense' }).sum(:amount)
+    transactions.expense.sum(:amount)
   end
 
   def balance

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -6,27 +6,20 @@ class Transaction < ApplicationRecord
 
   enumerize :status, in: %i[pending paid cancelled], default: :pending, scope: :shallow, predicates: true
   enumerize :recurring_frequency, in: %i[weekly monthly quarterly yearly], scope: :shallow
+  enumerize :transaction_type, in: %i[income expense], default: :expense, scope: :shallow, predicates: true
 
   validates :amount, presence: true, numericality: { greater_than: 0 }
   validates :description, presence: true, length: { minimum: 2, maximum: 200 }
   validates :transaction_date, presence: true
   validates :status, presence: true
+  validates :transaction_type, presence: true
   validates :recurring_frequency, presence: true, if: :is_recurring?
 
   scope :recurring, -> { where(is_recurring: true) }
   scope :approximate, -> { where(is_approximate: true) }
   scope :for_period, ->(start_date, end_date) { where(transaction_date: start_date..end_date) }
   scope :by_category, ->(category) { where(category: category) }
-  scope :by_category_type, ->(type) { joins(:category).merge(Category.public_send(type)) }
   scope :by_family, ->(family) { where(family: family) }
-
-  def income?
-    category&.income?
-  end
-
-  def expense?
-    category&.expense?
-  end
 
   def to_s
     description

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -4,7 +4,7 @@ class Transaction < ApplicationRecord
   belongs_to :category
   belongs_to :family
 
-  enumerize :status, in: %i[pending paid cancelled], default: :pending, scope: :shallow
+  enumerize :status, in: %i[pending paid cancelled], default: :pending, scope: :shallow, predicates: true
   enumerize :recurring_frequency, in: %i[weekly monthly quarterly yearly], scope: :shallow
 
   validates :amount, presence: true, numericality: { greater_than: 0 }
@@ -19,18 +19,6 @@ class Transaction < ApplicationRecord
   scope :by_category, ->(category) { where(category: category) }
   scope :by_category_type, ->(type) { joins(:category).merge(Category.public_send(type)) }
   scope :by_family, ->(family) { where(family: family) }
-
-  def pending?
-    status == 'pending'
-  end
-
-  def paid?
-    status == 'paid'
-  end
-
-  def cancelled?
-    status == 'cancelled'
-  end
 
   def income?
     category&.income?

--- a/config/locales/enumerize.pt-BR.yml
+++ b/config/locales/enumerize.pt-BR.yml
@@ -1,0 +1,25 @@
+pt-BR:
+  enumerize:
+    defaults:
+      # Category model - category_type
+      category_type:
+        income: "Receita"
+        expense: "Despesa"
+
+      # Transaction model - status
+      status:
+        pending: "Pendente"
+        paid: "Pago"
+        cancelled: "Cancelado"
+
+      # Transaction model - recurring_frequency
+      recurring_frequency:
+        weekly: "Semanal"
+        monthly: "Mensal"
+        quarterly: "Trimestral"
+        yearly: "Anual"
+
+      # Transaction model - transaction_type
+      transaction_type:
+        income: "Receita"
+        expense: "Despesa"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -15,7 +15,7 @@ pt-BR:
         current_password: Senha atual
     errors:
       messages:
-        record_invalid: "Registro inválido"
+        record_invalid: "A validação falhou: %{errors}"
         blank: não pode ficar em branco
         taken: já está em uso
         invalid: não é válido

--- a/db/migrate/20250605194841_add_transaction_type_to_transactions.rb
+++ b/db/migrate/20250605194841_add_transaction_type_to_transactions.rb
@@ -1,0 +1,6 @@
+class AddTransactionTypeToTransactions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :transactions, :transaction_type, :string, null: false, default: 'expense'
+    add_index :transactions, :transaction_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_05_191436) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_05_194841) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -81,11 +81,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_05_191436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "family_id", null: false
+    t.string "transaction_type", default: "expense", null: false
     t.index ["category_id"], name: "index_transactions_on_category_id"
     t.index ["family_id"], name: "index_transactions_on_family_id"
     t.index ["is_recurring"], name: "index_transactions_on_is_recurring"
     t.index ["status"], name: "index_transactions_on_status"
     t.index ["transaction_date"], name: "index_transactions_on_transaction_date"
+    t.index ["transaction_type"], name: "index_transactions_on_transaction_type"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     description { 'Transação de teste' }
     transaction_date { Date.current }
     status { :pending }
+    transaction_type { :expense }
     is_recurring { false }
     is_approximate { false }
     notes { 'Notas da transação' }
@@ -32,10 +33,12 @@ FactoryBot.define do
     end
 
     trait :income do
+      transaction_type { :income }
       association :category, factory: %i[category income]
     end
 
     trait :expense do
+      transaction_type { :expense }
       association :category, factory: %i[category expense]
     end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -13,6 +13,31 @@ RSpec.describe Category, type: :model do
     it { is_expected.to enumerize(:category_type).in(:income, :expense).with_default(:expense) }
   end
 
+  describe 'I18n translations' do
+    around do |example|
+      I18n.with_locale('pt-BR') { example.run }
+    end
+
+    describe 'category_type' do
+      let(:income_category) { build(:category, category_type: :income) }
+      let(:expense_category) { build(:category, category_type: :expense) }
+
+      it 'translates income to Portuguese' do
+        expect(income_category.category_type.text).to eq('Receita')
+      end
+
+      it 'translates expense to Portuguese' do
+        expect(expense_category.category_type.text).to eq('Despesa')
+      end
+
+      it 'provides all translated options' do
+        translated_options = Category.category_type.options
+        expect(translated_options).to include(['Receita', 'income'])
+        expect(translated_options).to include(['Despesa', 'expense'])
+      end
+    end
+  end
+
   describe 'scopes' do
     let!(:income_category) { create(:category, category_type: :income) }
     let!(:expense_category) { create(:category, category_type: :expense) }

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -17,24 +17,17 @@ RSpec.describe Category, type: :model do
     let!(:income_category) { create(:category, category_type: :income) }
     let!(:expense_category) { create(:category, category_type: :expense) }
 
-    describe '.incomes' do
+    describe '.income' do
       it 'returns only income categories' do
-        expect(described_class.incomes).to include(income_category)
-        expect(described_class.incomes).not_to include(expense_category)
+        expect(described_class.income).to include(income_category)
+        expect(described_class.income).not_to include(expense_category)
       end
     end
 
-    describe '.expenses' do
+    describe '.expense' do
       it 'returns only expense categories' do
-        expect(described_class.expenses).to include(expense_category)
-        expect(described_class.expenses).not_to include(income_category)
-      end
-    end
-
-    describe '.by_type' do
-      it 'filters by specific type' do
-        expect(described_class.by_type(:income)).to include(income_category)
-        expect(described_class.by_type(:expense)).to include(expense_category)
+        expect(described_class.expense).to include(expense_category)
+        expect(described_class.expense).not_to include(income_category)
       end
     end
   end

--- a/spec/models/family_spec.rb
+++ b/spec/models/family_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Family, type: :model do
     it 'can have multiple transactions' do
       transaction1 = create(:transaction, family: family, category: category)
       transaction2 = create(:transaction, family: family, category: category)
-      
+
       expect(family.transactions).to include(transaction1, transaction2)
       expect(family.transactions.count).to eq(2)
     end
@@ -48,7 +48,7 @@ RSpec.describe Family, type: :model do
       transaction1 = create(:transaction, family: family, category: category)
       transaction2 = create(:transaction, family: family, category: category)
       transaction_ids = [transaction1.id, transaction2.id]
-      
+
       expect { family.destroy }.to change { Transaction.count }.by(-2)
       expect(Transaction.where(id: transaction_ids)).to be_empty
     end
@@ -56,14 +56,12 @@ RSpec.describe Family, type: :model do
 
   describe 'financial calculations' do
     let(:family) { create(:family, user: user) }
-    let(:income_category) { create(:category, :income) }
-    let(:expense_category) { create(:category, :expense) }
 
     before do
-      create(:transaction, amount: 100.00, family: family, category: income_category)
-      create(:transaction, amount: 200.00, family: family, category: income_category)
-      create(:transaction, amount: 50.00, family: family, category: expense_category)
-      create(:transaction, amount: 75.00, family: family, category: expense_category)
+      create(:transaction, :income, amount: 100.00, family: family)
+      create(:transaction, :income, amount: 200.00, family: family)
+      create(:transaction, :expense, amount: 50.00, family: family)
+      create(:transaction, :expense, amount: 75.00, family: family)
     end
 
     describe '#total_income' do
@@ -115,23 +113,21 @@ RSpec.describe Family, type: :model do
     let(:category) { create(:category) }
 
     before do
-      @current_month_transaction = create(:transaction, 
-        transaction_date: Date.current.beginning_of_month + 5.days, 
-        family: family, 
-        category: category
-      )
-      @last_month_transaction = create(:transaction, 
-        transaction_date: 1.month.ago, 
-        family: family, 
-        category: category
-      )
+      @current_month_transaction = create(:transaction,
+                                          transaction_date: Date.current.beginning_of_month + 5.days,
+                                          family: family,
+                                          category: category)
+      @last_month_transaction = create(:transaction,
+                                       transaction_date: 1.month.ago,
+                                       family: family,
+                                       category: category)
     end
 
     describe '#transactions_for_period' do
       it 'returns transactions within the specified period' do
         start_date = Date.current.beginning_of_month
         end_date = Date.current.end_of_month
-        
+
         result = family.transactions_for_period(start_date, end_date)
         expect(result).to include(@current_month_transaction)
         expect(result).not_to include(@last_month_transaction)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -291,4 +291,85 @@ RSpec.describe Transaction, type: :model do
       end
     end
   end
+
+  describe 'I18n translations' do
+    around do |example|
+      I18n.with_locale('pt-BR') { example.run }
+    end
+
+    describe 'status' do
+      let(:pending_transaction) { build(:transaction, status: :pending) }
+      let(:paid_transaction) { build(:transaction, status: :paid) }
+      let(:cancelled_transaction) { build(:transaction, status: :cancelled) }
+
+      it 'translates pending to Portuguese' do
+        expect(pending_transaction.status.text).to eq('Pendente')
+      end
+
+      it 'translates paid to Portuguese' do
+        expect(paid_transaction.status.text).to eq('Pago')
+      end
+
+      it 'translates cancelled to Portuguese' do
+        expect(cancelled_transaction.status.text).to eq('Cancelado')
+      end
+
+      it 'provides all translated status options' do
+        translated_options = Transaction.status.options
+        expect(translated_options).to include(['Pendente', 'pending'])
+        expect(translated_options).to include(['Pago', 'paid'])
+        expect(translated_options).to include(['Cancelado', 'cancelled'])
+      end
+    end
+
+    describe 'recurring_frequency' do
+      let(:weekly_transaction) { build(:transaction, recurring_frequency: :weekly) }
+      let(:monthly_transaction) { build(:transaction, recurring_frequency: :monthly) }
+      let(:quarterly_transaction) { build(:transaction, recurring_frequency: :quarterly) }
+      let(:yearly_transaction) { build(:transaction, recurring_frequency: :yearly) }
+
+      it 'translates weekly to Portuguese' do
+        expect(weekly_transaction.recurring_frequency.text).to eq('Semanal')
+      end
+
+      it 'translates monthly to Portuguese' do
+        expect(monthly_transaction.recurring_frequency.text).to eq('Mensal')
+      end
+
+      it 'translates quarterly to Portuguese' do
+        expect(quarterly_transaction.recurring_frequency.text).to eq('Trimestral')
+      end
+
+      it 'translates yearly to Portuguese' do
+        expect(yearly_transaction.recurring_frequency.text).to eq('Anual')
+      end
+
+      it 'provides all translated frequency options' do
+        translated_options = Transaction.recurring_frequency.options
+        expect(translated_options).to include(['Semanal', 'weekly'])
+        expect(translated_options).to include(['Mensal', 'monthly'])
+        expect(translated_options).to include(['Trimestral', 'quarterly'])
+        expect(translated_options).to include(['Anual', 'yearly'])
+      end
+    end
+
+    describe 'transaction_type' do
+      let(:income_transaction) { build(:transaction, transaction_type: :income) }
+      let(:expense_transaction) { build(:transaction, transaction_type: :expense) }
+
+      it 'translates income to Portuguese' do
+        expect(income_transaction.transaction_type.text).to eq('Receita')
+      end
+
+      it 'translates expense to Portuguese' do
+        expect(expense_transaction.transaction_type.text).to eq('Despesa')
+      end
+
+      it 'provides all translated transaction_type options' do
+        translated_options = Transaction.transaction_type.options
+        expect(translated_options).to include(['Receita', 'income'])
+        expect(translated_options).to include(['Despesa', 'expense'])
+      end
+    end
+  end
 end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Transaction, type: :model do
     it { should validate_length_of(:description).is_at_least(2).is_at_most(200) }
     it { should validate_presence_of(:transaction_date) }
     it { should validate_presence_of(:status) }
+    it { should validate_presence_of(:transaction_type) }
 
     context 'when is_recurring is true' do
       let(:transaction) { build(:transaction, is_recurring: true) }
@@ -37,6 +38,7 @@ RSpec.describe Transaction, type: :model do
   describe 'enumerize' do
     it { should enumerize(:status).in(:pending, :paid, :cancelled).with_default(:pending) }
     it { should enumerize(:recurring_frequency).in(:weekly, :monthly, :quarterly, :yearly) }
+    it { should enumerize(:transaction_type).in(:income, :expense).with_default(:expense) }
   end
 
   describe 'scopes' do
@@ -108,17 +110,17 @@ RSpec.describe Transaction, type: :model do
       end
     end
 
-    describe '.by_category_type' do
-      it 'returns transactions for income categories' do
-        result = Transaction.by_category_type('income')
-        expect(result).to include(income_transaction)
-        expect(result).to_not include(expense_transaction)
+    describe '.income' do
+      it 'returns only income transactions' do
+        expect(Transaction.income).to include(income_transaction)
+        expect(Transaction.income).to_not include(expense_transaction)
       end
+    end
 
-      it 'returns transactions for expense categories' do
-        result = Transaction.by_category_type('expense')
-        expect(result).to include(expense_transaction)
-        expect(result).to_not include(income_transaction)
+    describe '.expense' do
+      it 'returns only expense transactions' do
+        expect(Transaction.expense).to include(expense_transaction)
+        expect(Transaction.expense).to_not include(income_transaction)
       end
     end
 
@@ -176,29 +178,25 @@ RSpec.describe Transaction, type: :model do
     end
 
     describe '#income?' do
-      it 'returns true when category is income' do
-        income_category = create(:category, :income)
-        transaction.category = income_category
+      it 'returns true when transaction_type is income' do
+        transaction.transaction_type = :income
         expect(transaction.income?).to be true
       end
 
-      it 'returns false when category is expense' do
-        expense_category = create(:category, :expense)
-        transaction.category = expense_category
+      it 'returns false when transaction_type is expense' do
+        transaction.transaction_type = :expense
         expect(transaction.income?).to be false
       end
     end
 
     describe '#expense?' do
-      it 'returns true when category is expense' do
-        expense_category = create(:category, :expense)
-        transaction.category = expense_category
+      it 'returns true when transaction_type is expense' do
+        transaction.transaction_type = :expense
         expect(transaction.expense?).to be true
       end
 
-      it 'returns false when category is income' do
-        income_category = create(:category, :income)
-        transaction.category = income_category
+      it 'returns false when transaction_type is income' do
+        transaction.transaction_type = :income
         expect(transaction.expense?).to be false
       end
     end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -110,13 +110,13 @@ RSpec.describe Transaction, type: :model do
 
     describe '.by_category_type' do
       it 'returns transactions for income categories' do
-        result = Transaction.by_category_type(:income)
+        result = Transaction.by_category_type('income')
         expect(result).to include(income_transaction)
         expect(result).to_not include(expense_transaction)
       end
 
       it 'returns transactions for expense categories' do
-        result = Transaction.by_category_type(:expense)
+        result = Transaction.by_category_type('expense')
         expect(result).to include(expense_transaction)
         expect(result).to_not include(income_transaction)
       end


### PR DESCRIPTION
# Descrição
- Refatoração dos modelos para deixar mais clean, usando métodos provinientes da gem enumerize
- Adicionada coluna para tipo de transacao na transacao evitando joins em relatórios
- Adiciona alterações schema
- Adiciona textos em pt-br para os enumerize