### PR TITLE
[HOTFIX] Redirect para dashboard quebrando quando não existia família

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  protected
+
+  def ensure_user_has_family
+    return unless user_signed_in?
+    return if current_user.family.present?
+
+    flash[:info] =
+      'Seja bem-vindo! O primeiro passo da sua jornada é criar sua família, assim poderemos ajuda-lo com seu orçamento.'
+    redirect_to new_family_path
+  end
+
+  def user_needs_family_setup?
+    user_signed_in? && current_user.family.blank?
+  end
+  helper_method :user_needs_family_setup?
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,7 @@
 # Dashboard controller for displaying family budget overview
 class DashboardController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_user_has_family
 
   def index
     @current_month_income = current_user.family.transactions.income.current_month.sum(:amount)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,12 @@
 class HomeController < ApplicationController
   def index
-    # Redireciona usuários logados para o dashboard
-    redirect_to dashboard_path if user_signed_in?
+    return unless user_signed_in?
+
+    if current_user.family.blank?
+      flash[:info] = "Seja bem-vindo! O primeiro passo da sua jornada é criar sua família, assim poderemos ajuda-lo com seu orçamento."
+      redirect_to new_family_path
+    else
+      redirect_to dashboard_path
+    end
   end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,6 +1,7 @@
 # Transactions controller for managing family transactions
 class TransactionsController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_user_has_family
   before_action :set_transaction, only: %i[show edit update destroy]
 
   def index

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,16 +21,21 @@
   <body>
     <%= render "shared/navbar" %>
 
-    <% if notice %>
-      <div class="alert alert-success alert-dismissible fade show m-3" role="alert">
-        <%= notice %>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    <% end %>
-
-    <% if alert %>
-      <div class="alert alert-danger alert-dismissible fade show m-3" role="alert">
-        <%= alert %>
+    <% flash.each do |key, value| %>
+      <% alert_class = case key.to_s
+                       when 'notice'
+                         'alert-success'
+                       when 'alert'
+                         'alert-danger'
+                       when 'info'
+                         'alert-info'
+                       when 'warning'
+                         'alert-warning'
+                       else
+                         'alert-primary'
+                       end %>
+      <div class="alert <%= alert_class %> alert-dismissible fade show m-3" role="alert">
+        <%= value %>
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
     <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,9 +1,16 @@
 <nav class="navbar navbar-expand-lg navbar-dark" style="background: linear-gradient(135deg, #4b6cb7 0%, #182848 100%);">
   <div class="container">
     <% if user_signed_in? %>
-      <%= link_to dashboard_path, class: "navbar-brand" do %>
-        <i class="bi bi-wallet2 me-2"></i>
-        Family Budget
+      <% if user_needs_family_setup? %>
+        <%= link_to new_family_path, class: "navbar-brand" do %>
+          <i class="bi bi-wallet2 me-2"></i>
+          Family Budget
+        <% end %>
+      <% else %>
+        <%= link_to dashboard_path, class: "navbar-brand" do %>
+          <i class="bi bi-wallet2 me-2"></i>
+          Family Budget
+        <% end %>
       <% end %>
     <% else %>
       <a class="navbar-brand" href="/">
@@ -22,27 +29,31 @@
           </li>
         <% end %>
         <% if user_signed_in? %>
-          <li class="nav-item">
-            <%= link_to "Dashboard", dashboard_path, class: "nav-link #{current_page?(dashboard_path) ? 'active' : ''}" %>
-          </li>
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Finanças
-            </a>
-            <ul class="dropdown-menu">
-              <li><%= link_to "Todas as Transações", transactions_path, class: "dropdown-item" %></li>
-              <li><%= link_to "Nova Transação", new_transaction_path, class: "dropdown-item" %></li>
-              <li><hr class="dropdown-divider"></li>
-              <li><%= link_to "Relatórios", "#", class: "dropdown-item disabled" %></li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <% if current_user.family.present? %>
+          <% if user_needs_family_setup? %>
+            <!-- User needs to create family first -->
+            <li class="nav-item">
+              <%= link_to "Criar Família", new_family_path, class: "nav-link #{current_page?(new_family_path) ? 'active' : ''}" %>
+            </li>
+          <% else %>
+            <!-- User has family, show full navigation -->
+            <li class="nav-item">
+              <%= link_to "Dashboard", dashboard_path, class: "nav-link #{current_page?(dashboard_path) ? 'active' : ''}" %>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Finanças
+              </a>
+              <ul class="dropdown-menu">
+                <li><%= link_to "Todas as Transações", transactions_path, class: "dropdown-item" %></li>
+                <li><%= link_to "Nova Transação", new_transaction_path, class: "dropdown-item" %></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><%= link_to "Relatórios", "#", class: "dropdown-item disabled" %></li>
+              </ul>
+            </li>
+            <li class="nav-item">
               <%= link_to "Gerenciar Família", family_path, class: "nav-link" %>
-            <% else %>
-              <%= link_to "Criar Família", new_family_path, class: "nav-link" %>
-            <% end %>
-          </li>
+            </li>
+          <% end %>
         <% end %>
       </ul>
       <div class="d-flex">

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -48,4 +48,21 @@ RSpec.describe DashboardController, type: :controller do
       expect(response).to redirect_to(new_user_session_path)
     end
   end
+
+  describe 'when user does not have a family' do
+    let(:user_without_family) { create(:user) }
+
+    before do
+      sign_in user_without_family
+      get :index
+    end
+
+    it 'redirects to new family path' do
+      expect(response).to redirect_to(new_family_path)
+    end
+
+    it 'sets info flash message' do
+      expect(flash[:info]).to eq("Seja bem-vindo! O primeiro passo da sua jornada é criar sua família, assim poderemos ajuda-lo com seu orçamento.")
+    end
+  end
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -21,10 +21,29 @@ RSpec.describe 'Home', type: :request do
         sign_in user
       end
 
-      it 'redirects to dashboard' do
-        get root_path
-        expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to(dashboard_path)
+      context 'when user has a family' do
+        before do
+          create(:family, user: user)
+        end
+
+        it 'redirects to dashboard' do
+          get root_path
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(dashboard_path)
+        end
+      end
+
+      context 'when user does not have a family' do
+        it 'redirects to new family path' do
+          get root_path
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(new_family_path)
+        end
+
+        it 'sets welcome flash message' do
+          get root_path
+          expect(flash[:info]).to eq('Seja bem-vindo! O primeiro passo da sua jornada é criar sua família, assim poderemos ajuda-lo com seu orçamento.')
+        end
       end
     end
   end

--- a/spec/views/shared/_navbar_spec.rb
+++ b/spec/views/shared/_navbar_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'shared/_navbar', type: :view do
+  before do
+    # Include ApplicationController helpers in view tests
+    view.extend ApplicationController._helpers
+  end
   context 'when user is not signed in' do
     before do
       allow(view).to receive(:user_signed_in?).and_return(false)
@@ -39,39 +43,76 @@ RSpec.describe 'shared/_navbar', type: :view do
     before do
       allow(view).to receive(:user_signed_in?).and_return(true)
       allow(view).to receive(:current_user).and_return(user)
-      render partial: 'shared/navbar'
     end
 
-    it 'displays dashboard link' do
-      expect(rendered).to have_link('Dashboard')
+    context 'when user needs family setup' do
+      before do
+        allow(view).to receive(:user_needs_family_setup?).and_return(true)
+        render partial: 'shared/navbar'
+      end
+
+      it 'displays create family link' do
+        expect(rendered).to have_link('Criar Família', href: new_family_path)
+      end
+
+      it 'does not display dashboard link' do
+        expect(rendered).not_to have_link('Dashboard')
+      end
+
+      it 'does not display finances dropdown' do
+        expect(rendered).not_to have_content('Finanças')
+      end
+
+      it 'displays user profile dropdown' do
+        expect(rendered).to have_content(user.profile.first_name)
+      end
+
+      it 'does not display login button' do
+        expect(rendered).not_to have_link('Entrar')
+      end
+
+      it 'does not display sign up button' do
+        expect(rendered).not_to have_link('Cadastrar')
+      end
     end
 
-    it 'displays finances dropdown' do
-      expect(rendered).to have_content('Finanças')
-    end
+    context 'when user has family' do
+      before do
+        allow(view).to receive(:user_needs_family_setup?).and_return(false)
+        render partial: 'shared/navbar'
+      end
 
-    it 'displays finances dropdown items' do
-      expect(rendered).to have_link('Todas as Transações')
-      expect(rendered).to have_link('Nova Transação')
-      expect(rendered).to have_link('Relatórios')
-    end
+      it 'displays dashboard link' do
+        expect(rendered).to have_link('Dashboard')
+      end
 
-    it 'displays user profile dropdown' do
-      expect(rendered).to have_content(user.profile.first_name)
-    end
+      it 'displays finances dropdown' do
+        expect(rendered).to have_content('Finanças')
+      end
 
-    it 'displays user profile dropdown items' do
-      expect(rendered).to have_link('Meu Perfil')
-      expect(rendered).to have_link('Configurações')
-      expect(rendered).to have_content('Sair')
-    end
+      it 'displays finances dropdown items' do
+        expect(rendered).to have_link('Todas as Transações')
+        expect(rendered).to have_link('Nova Transação')
+        expect(rendered).to have_link('Relatórios')
+      end
 
-    it 'does not display login button' do
-      expect(rendered).not_to have_link('Entrar')
-    end
+      it 'displays user profile dropdown' do
+        expect(rendered).to have_content(user.profile.first_name)
+      end
 
-    it 'does not display sign up button' do
-      expect(rendered).not_to have_link('Cadastrar')
+      it 'displays user profile dropdown items' do
+        expect(rendered).to have_link('Meu Perfil')
+        expect(rendered).to have_link('Configurações')
+        expect(rendered).to have_content('Sair')
+      end
+
+      it 'does not display login button' do
+        expect(rendered).not_to have_link('Entrar')
+      end
+
+      it 'does not display sign up button' do
+        expect(rendered).not_to have_link('Cadastrar')
+      end
     end
   end
 end


### PR DESCRIPTION
# Descrição
A implementação do redirect para o dashboard quebrava quando o usuário não tinha família cadastrada ( usuário novo)

- criado métodos auxiliares para garantir que o usuário tenha cadastrado a família guiando o usuário para faze-lo
